### PR TITLE
feat: add blog with introductory post and SEO optimization

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "lucide-react": "^0.468.0",
-    "mermaid": "^11.12.3",
+    "mermaid": "^11.13.0",
     "next": "^15.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.468.0
         version: 0.468.0(react@19.2.4)
       mermaid:
-        specifier: ^11.12.3
-        version: 11.12.3
+        specifier: ^11.13.0
+        version: 11.13.0
       next:
         specifier: ^15.2.0
         version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -58,20 +58,20 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
-  '@chevrotain/cst-dts-gen@11.1.1':
-    resolution: {integrity: sha512-fRHyv6/f542qQqiRGalrfJl/evD39mAvbJLCekPazhiextEatq1Jx1K/i9gSd5NNO0ds03ek0Cbo/4uVKmOBcw==}
+  '@chevrotain/cst-dts-gen@11.1.2':
+    resolution: {integrity: sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==}
 
-  '@chevrotain/gast@11.1.1':
-    resolution: {integrity: sha512-Ko/5vPEYy1vn5CbCjjvnSO4U7GgxyGm+dfUZZJIWTlQFkXkyym0jFYrWEU10hyCjrA7rQtiHtBr0EaZqvHFZvg==}
+  '@chevrotain/gast@11.1.2':
+    resolution: {integrity: sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==}
 
-  '@chevrotain/regexp-to-ast@11.1.1':
-    resolution: {integrity: sha512-ctRw1OKSXkOrR8VTvOxrQ5USEc4sNrfwXHa1NuTcR7wre4YbjPcKw+82C2uylg/TEwFRgwLmbhlln4qkmDyteg==}
+  '@chevrotain/regexp-to-ast@11.1.2':
+    resolution: {integrity: sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==}
 
-  '@chevrotain/types@11.1.1':
-    resolution: {integrity: sha512-wb2ToxG8LkgPYnKe9FH8oGn3TMCBdnwiuNC5l5y+CtlaVRbCytU0kbVsk6CGrqTL4ZN4ksJa0TXOYbxpbthtqw==}
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
-  '@chevrotain/utils@11.1.1':
-    resolution: {integrity: sha512-71eTYMzYXYSFPrbg/ZwftSaSDld7UYlS8OQa3lNnn9jzNtpFbaReRRyghzqS7rI3CDaorqpPJJcXGHK+FE1TVQ==}
+  '@chevrotain/utils@11.1.2':
+    resolution: {integrity: sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==}
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
@@ -235,8 +235,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@mermaid-js/parser@1.0.0':
-    resolution: {integrity: sha512-vvK0Hi/VWndxoh03Mmz6wa1KDriSPjS2XMZL/1l19HFwygiObEEoEwSDxOqyLzzAI6J2PU3261JjTMTO7x+BPw==}
+  '@mermaid-js/parser@1.0.1':
+    resolution: {integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==}
 
   '@next/env@15.5.12':
     resolution: {integrity: sha512-pUvdJN1on574wQHjaBfNGDt9Mz5utDSZFsIIQkMzPgNS8ZvT4H2mwOrOIClwsQOb6EGx5M76/CZr6G8i6pSpLg==}
@@ -523,6 +523,9 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -545,8 +548,8 @@ packages:
     peerDependencies:
       chevrotain: ^11.0.0
 
-  chevrotain@11.1.1:
-    resolution: {integrity: sha512-f0yv5CPKaFxfsPTBzX7vGuim4oIC1/gcS7LUGdBSwl2dU6+FON6LVUksdOo1qJjoUvXNn45urgh8C+0a24pACQ==}
+  chevrotain@11.1.2:
+    resolution: {integrity: sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -727,11 +730,11 @@ packages:
     resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
     engines: {node: '>=12'}
 
-  dagre-d3-es@7.0.13:
-    resolution: {integrity: sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==}
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
-  dayjs@1.11.19:
-    resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
   delaunator@5.0.1:
     resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
@@ -747,8 +750,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  dompurify@3.3.1:
-    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
+  dompurify@3.3.3:
+    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
   enhanced-resolve@5.19.0:
     resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
@@ -784,8 +787,8 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
-  katex@0.16.29:
-    resolution: {integrity: sha512-ef+wYUDehNgScWoA0ZhEngsNqUv9uIj4ftd/PapQmT+E85lXI6Wx6BvJO48v80Vhj3t/IjEoZWw9/ZPe8kHwHg==}
+  katex@0.16.38:
+    resolution: {integrity: sha512-cjHooZUmIAUmDsHBN+1n8LaZdpmbj03LtYeYPyuYB7OuloiaeaV6N4LcfjcnHVzGWjVQmKrxxTrpDcmSzEZQwQ==}
     hasBin: true
 
   khroma@2.1.0:
@@ -890,8 +893,8 @@ packages:
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
-  mermaid@11.12.3:
-    resolution: {integrity: sha512-wN5ZSgJQIC+CHJut9xaKWsknLxaFBwCPwPkGTSUYrTiHORWvpT8RxGk849HPnpUAQ+/9BPRqYb80jTpearrHzQ==}
+  mermaid@11.13.0:
+    resolution: {integrity: sha512-fEnci+Immw6lKMFI8sqzjlATTyjLkRa6axrEgLV2yHTfv8r+h1wjFbV6xeRtd4rUV1cS4EpR9rwp3Rci7TRWDw==}
 
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
@@ -908,8 +911,8 @@ packages:
   micromark-util-types@2.0.2:
     resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
-  mlly@1.8.0:
-    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+  mlly@1.8.1:
+    resolution: {integrity: sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -1053,8 +1056,8 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
-  tinyexec@1.0.2:
-    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+  tinyexec@1.0.4:
+    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
 
   trim-lines@3.0.1:
@@ -1133,26 +1136,26 @@ snapshots:
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.6.0
-      tinyexec: 1.0.2
+      tinyexec: 1.0.4
 
   '@braintree/sanitize-url@7.1.2': {}
 
-  '@chevrotain/cst-dts-gen@11.1.1':
+  '@chevrotain/cst-dts-gen@11.1.2':
     dependencies:
-      '@chevrotain/gast': 11.1.1
-      '@chevrotain/types': 11.1.1
+      '@chevrotain/gast': 11.1.2
+      '@chevrotain/types': 11.1.2
       lodash-es: 4.17.23
 
-  '@chevrotain/gast@11.1.1':
+  '@chevrotain/gast@11.1.2':
     dependencies:
-      '@chevrotain/types': 11.1.1
+      '@chevrotain/types': 11.1.2
       lodash-es: 4.17.23
 
-  '@chevrotain/regexp-to-ast@11.1.1': {}
+  '@chevrotain/regexp-to-ast@11.1.2': {}
 
-  '@chevrotain/types@11.1.1': {}
+  '@chevrotain/types@11.1.2': {}
 
-  '@chevrotain/utils@11.1.1': {}
+  '@chevrotain/utils@11.1.2': {}
 
   '@emnapi/runtime@1.8.1':
     dependencies:
@@ -1165,7 +1168,7 @@ snapshots:
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@iconify/types': 2.0.0
-      mlly: 1.8.0
+      mlly: 1.8.1
 
   '@img/colour@1.0.0':
     optional: true
@@ -1283,7 +1286,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@mermaid-js/parser@1.0.0':
+  '@mermaid-js/parser@1.0.1':
     dependencies:
       langium: 4.2.1
 
@@ -1565,6 +1568,11 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
   acorn@8.16.0: {}
 
   caniuse-lite@1.0.30001772: {}
@@ -1575,18 +1583,18 @@ snapshots:
 
   character-entities-legacy@3.0.0: {}
 
-  chevrotain-allstar@0.3.1(chevrotain@11.1.1):
+  chevrotain-allstar@0.3.1(chevrotain@11.1.2):
     dependencies:
-      chevrotain: 11.1.1
+      chevrotain: 11.1.2
       lodash-es: 4.17.23
 
-  chevrotain@11.1.1:
+  chevrotain@11.1.2:
     dependencies:
-      '@chevrotain/cst-dts-gen': 11.1.1
-      '@chevrotain/gast': 11.1.1
-      '@chevrotain/regexp-to-ast': 11.1.1
-      '@chevrotain/types': 11.1.1
-      '@chevrotain/utils': 11.1.1
+      '@chevrotain/cst-dts-gen': 11.1.2
+      '@chevrotain/gast': 11.1.2
+      '@chevrotain/regexp-to-ast': 11.1.2
+      '@chevrotain/types': 11.1.2
+      '@chevrotain/utils': 11.1.2
       lodash-es: 4.17.23
 
   client-only@0.0.1: {}
@@ -1788,12 +1796,12 @@ snapshots:
       d3-transition: 3.0.1(d3-selection@3.0.0)
       d3-zoom: 3.0.0
 
-  dagre-d3-es@7.0.13:
+  dagre-d3-es@7.0.14:
     dependencies:
       d3: 7.9.0
       lodash-es: 4.17.23
 
-  dayjs@1.11.19: {}
+  dayjs@1.11.20: {}
 
   delaunator@5.0.1:
     dependencies:
@@ -1807,7 +1815,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  dompurify@3.3.1:
+  dompurify@3.3.3:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -1850,7 +1858,7 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  katex@0.16.29:
+  katex@0.16.38:
     dependencies:
       commander: 8.3.0
 
@@ -1858,8 +1866,8 @@ snapshots:
 
   langium@4.2.1:
     dependencies:
-      chevrotain: 11.1.1
-      chevrotain-allstar: 0.3.1(chevrotain@11.1.1)
+      chevrotain: 11.1.2
+      chevrotain-allstar: 0.3.1(chevrotain@11.1.2)
       vscode-languageserver: 9.0.1
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
@@ -1941,21 +1949,22 @@ snapshots:
       unist-util-visit: 5.1.0
       vfile: 6.0.3
 
-  mermaid@11.12.3:
+  mermaid@11.13.0:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.0
-      '@mermaid-js/parser': 1.0.0
+      '@mermaid-js/parser': 1.0.1
       '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
       cytoscape: 3.33.1
       cytoscape-cose-bilkent: 4.1.0(cytoscape@3.33.1)
       cytoscape-fcose: 2.2.0(cytoscape@3.33.1)
       d3: 7.9.0
       d3-sankey: 0.12.3
-      dagre-d3-es: 7.0.13
-      dayjs: 1.11.19
-      dompurify: 3.3.1
-      katex: 0.16.29
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.20
+      dompurify: 3.3.3
+      katex: 0.16.38
       khroma: 2.1.0
       lodash-es: 4.17.23
       marked: 16.4.2
@@ -1981,7 +1990,7 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  mlly@1.8.0:
+  mlly@1.8.1:
     dependencies:
       acorn: 8.16.0
       pathe: 2.0.3
@@ -2032,7 +2041,7 @@ snapshots:
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
-      mlly: 1.8.0
+      mlly: 1.8.1
       pathe: 2.0.3
 
   points-on-curve@0.2.0: {}
@@ -2154,7 +2163,7 @@ snapshots:
 
   tapable@2.3.0: {}
 
-  tinyexec@1.0.2: {}
+  tinyexec@1.0.4: {}
 
   trim-lines@3.0.1: {}
 

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { getAllPosts, getPost } from "@/lib/blog";
+import { BlogPostJsonLd } from "@/components/blog-post-json-ld";
 import type { Metadata } from "next";
 
 export function generateStaticParams() {
@@ -17,12 +18,25 @@ export async function generateMetadata({
   return {
     title: `${post.title} - PortZero Blog`,
     description: post.description,
+    alternates: {
+      canonical: `https://goport0.dev/blog/${post.slug}`,
+    },
     openGraph: {
       title: post.title,
       description: post.description,
+      url: `https://goport0.dev/blog/${post.slug}`,
+      siteName: "PortZero",
       type: "article",
       publishedTime: post.date,
+      modifiedTime: post.date,
       authors: [post.author],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: post.title,
+      description: post.description,
+      creator: "@davidviejodev",
+      site: "@davidviejodev",
     },
   };
 }
@@ -39,33 +53,43 @@ export default async function BlogPost({
   const PostContent = (await import(`../posts/${slug}`)).default;
 
   return (
-    <article className="blog-content">
-      <header className="mb-12">
-        <div className="flex items-center gap-3 text-sm text-zinc-500">
-          <time dateTime={post.date}>
-            {new Date(post.date).toLocaleDateString("en-US", {
-              year: "numeric",
-              month: "long",
-              day: "numeric",
-            })}
-          </time>
-          <span>&middot;</span>
-          <span>{post.readingTime}</span>
-        </div>
-        <h1 className="mt-3 text-4xl font-bold tracking-tight leading-tight">
-          {post.title}
-        </h1>
-        <p className="mt-4 text-lg text-zinc-400 leading-relaxed">
-          {post.description}
-        </p>
-        <div className="mt-4 flex items-center gap-3">
-          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-violet-600 text-xs font-bold text-white">
-            DV
+    <>
+      <BlogPostJsonLd post={post} />
+      <article className="blog-content">
+        <header className="mb-12">
+          <div className="flex items-center gap-3 text-sm text-zinc-500">
+            <time dateTime={post.date}>
+              {new Date(post.date).toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}
+            </time>
+            <span>&middot;</span>
+            <span>{post.readingTime}</span>
           </div>
-          <span className="text-sm text-zinc-400">{post.author}</span>
-        </div>
-      </header>
-      <PostContent />
-    </article>
+          <h1 className="mt-3 text-4xl font-bold tracking-tight leading-tight">
+            {post.title}
+          </h1>
+          <p className="mt-4 text-lg text-zinc-400 leading-relaxed">
+            {post.description}
+          </p>
+          <div className="mt-4 flex items-center gap-3">
+            <a
+              href="https://x.com/davidviejodev"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-3 transition-colors hover:text-zinc-200"
+            >
+              <div className="flex h-8 w-8 items-center justify-center rounded-full bg-violet-600 text-xs font-bold text-white">
+                DV
+              </div>
+              <span className="text-sm text-zinc-400">{post.author}</span>
+            </a>
+          </div>
+        </header>
+        <PostContent />
+      </article>
+    </>
   );
 }

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,71 @@
+import { notFound } from "next/navigation";
+import { getAllPosts, getPost } from "@/lib/blog";
+import type { Metadata } from "next";
+
+export function generateStaticParams() {
+  return getAllPosts().map((post) => ({ slug: post.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const post = getPost(slug);
+  if (!post) return {};
+  return {
+    title: `${post.title} - PortZero Blog`,
+    description: post.description,
+    openGraph: {
+      title: post.title,
+      description: post.description,
+      type: "article",
+      publishedTime: post.date,
+      authors: [post.author],
+    },
+  };
+}
+
+export default async function BlogPost({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const post = getPost(slug);
+  if (!post) notFound();
+
+  const PostContent = (await import(`../posts/${slug}`)).default;
+
+  return (
+    <article className="blog-content">
+      <header className="mb-12">
+        <div className="flex items-center gap-3 text-sm text-zinc-500">
+          <time dateTime={post.date}>
+            {new Date(post.date).toLocaleDateString("en-US", {
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+            })}
+          </time>
+          <span>&middot;</span>
+          <span>{post.readingTime}</span>
+        </div>
+        <h1 className="mt-3 text-4xl font-bold tracking-tight leading-tight">
+          {post.title}
+        </h1>
+        <p className="mt-4 text-lg text-zinc-400 leading-relaxed">
+          {post.description}
+        </p>
+        <div className="mt-4 flex items-center gap-3">
+          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-violet-600 text-xs font-bold text-white">
+            DV
+          </div>
+          <span className="text-sm text-zinc-400">{post.author}</span>
+        </div>
+      </header>
+      <PostContent />
+    </article>
+  );
+}

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({
   const post = getPost(slug);
   if (!post) return {};
   return {
-    title: `${post.title} - PortZero Blog`,
+    title: `${post.title} | PortZero`,
     description: post.description,
     alternates: {
       canonical: `https://goport0.dev/blog/${post.slug}`,

--- a/apps/web/src/app/blog/layout.tsx
+++ b/apps/web/src/app/blog/layout.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+export default function BlogLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="min-h-screen">
+      <nav className="fixed top-0 left-0 right-0 z-50 border-b border-zinc-800/50 bg-zinc-950/80 backdrop-blur-xl">
+        <div className="mx-auto flex h-16 max-w-3xl items-center justify-between px-6">
+          <Link
+            href="/"
+            className="flex items-center gap-2 text-zinc-400 transition-colors hover:text-white"
+          >
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-violet-primary font-bold text-sm text-white">
+              PZ
+            </div>
+            <span className="text-lg font-semibold text-white">PortZero</span>
+          </Link>
+          <div className="flex items-center gap-6">
+            <Link
+              href="/blog"
+              className="text-sm text-zinc-400 transition-colors hover:text-white"
+            >
+              Blog
+            </Link>
+            <Link
+              href="/docs"
+              className="text-sm text-zinc-400 transition-colors hover:text-white"
+            >
+              Docs
+            </Link>
+            <Link
+              href="https://github.com/portzero-dev/portzero"
+              className="text-sm text-zinc-400 transition-colors hover:text-white"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              GitHub
+            </Link>
+          </div>
+        </div>
+      </nav>
+      <main className="pt-16">
+        <div className="mx-auto max-w-3xl px-6 py-16">{children}</div>
+      </main>
+      <footer className="border-t border-zinc-800/50 py-8">
+        <div className="mx-auto max-w-3xl px-6">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-1 text-sm text-zinc-500 transition-colors hover:text-zinc-300"
+          >
+            <ArrowLeft className="h-3 w-3" />
+            Back to PortZero
+          </Link>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/src/app/blog/page.tsx
+++ b/apps/web/src/app/blog/page.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+import { getAllPosts } from "@/lib/blog";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Blog - PortZero",
+  description:
+    "Updates, tutorials, and behind-the-scenes from the PortZero project.",
+};
+
+export default function BlogIndex() {
+  const posts = getAllPosts();
+
+  return (
+    <>
+      <h1 className="text-4xl font-bold tracking-tight">Blog</h1>
+      <p className="mt-2 text-lg text-zinc-400">
+        Updates, tutorials, and behind-the-scenes from the PortZero project.
+      </p>
+
+      <div className="mt-12 space-y-10">
+        {posts.map((post) => (
+          <article key={post.slug} className="group">
+            <Link href={`/blog/${post.slug}`} className="block">
+              <div className="flex items-center gap-3 text-sm text-zinc-500">
+                <time dateTime={post.date}>
+                  {new Date(post.date).toLocaleDateString("en-US", {
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
+                  })}
+                </time>
+                <span>&middot;</span>
+                <span>{post.readingTime}</span>
+              </div>
+              <h2 className="mt-2 text-2xl font-semibold tracking-tight text-zinc-100 transition-colors group-hover:text-violet-400">
+                {post.title}
+              </h2>
+              <p className="mt-2 text-zinc-400 leading-relaxed">
+                {post.description}
+              </p>
+              <div className="mt-3 flex gap-2">
+                {post.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-full bg-zinc-800/60 px-2.5 py-0.5 text-xs text-zinc-400"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </Link>
+          </article>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/app/blog/posts/introducing-portzero.tsx
+++ b/apps/web/src/app/blog/posts/introducing-portzero.tsx
@@ -1,0 +1,243 @@
+import { CodeBlock } from "@/components/code-block";
+
+export default async function IntroducingPortZero() {
+  return (
+    <div className="docs-content">
+      <h2>The Problem</h2>
+      <p>
+        If you work on more than one microservice at a time, you know the drill.
+        You spin up a frontend on <code>:3000</code>, an API on{" "}
+        <code>:8080</code>, maybe a worker on <code>:9090</code>. You juggle
+        ports, forget which service runs where, and when something breaks you
+        have no idea what request caused it.
+      </p>
+      <p>
+        Your browser history is full of <code>localhost:3000</code>,{" "}
+        <code>localhost:3001</code>, <code>localhost:8080</code>. You mix them up
+        between projects. And if you need someone else to see your local work?
+        Time to set up a tunnel.
+      </p>
+      <p>
+        I hit this problem daily. I tried the existing tools. Each solved part of
+        it, but none solved all of it. So I built PortZero.
+      </p>
+
+      <h2>What I Was Using Before</h2>
+
+      <h3>Nginx / Caddy / Traefik</h3>
+      <p>
+        Great reverse proxies — for production. For local dev, they&apos;re
+        overkill. You need config files, you need to manage them separately from
+        your services, and they don&apos;t know anything about your dev
+        processes. No traffic inspection, no process management, no hot-reload
+        awareness. They&apos;re designed for deployed infrastructure, not for{" "}
+        <code>pnpm dev</code>.
+      </p>
+
+      <h3>Ngrok</h3>
+      <p>
+        Ngrok is excellent at what it does: exposing local ports to the internet.
+        But it&apos;s a tunnel, not a local dev environment tool. You still need
+        to manage ports yourself, it doesn&apos;t give you stable local URLs
+        across projects, and there&apos;s no built-in traffic inspection,
+        mocking, or process management. It solves the &quot;show this to a
+        teammate&quot; problem, not the &quot;I have 5 services running
+        locally&quot; problem.
+      </p>
+
+      <h3>Portless (Vercel)</h3>
+      <p>
+        <a
+          href="https://github.com/nicepkg/portless"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Portless
+        </a>{" "}
+        tackles the same core problem: giving your local dev servers human-readable
+        URLs instead of random port numbers. It&apos;s a CLI tool from the Vercel
+        ecosystem that maps <code>.local</code> domains to your services.
+      </p>
+      <p>
+        Portless validated the problem — port juggling is real and developers
+        hate it. But it&apos;s CLI-only with no visual dashboard, no traffic
+        inspection, no request replay or mocking, and no process management. I
+        wanted something that went further: not just stable URLs, but a full
+        local dev companion that lets you see, debug, and simulate everything
+        flowing through your services.
+      </p>
+
+      <h2>What PortZero Does Differently</h2>
+      <p>
+        PortZero is a single Rust binary that combines five things that usually
+        require separate tools:
+      </p>
+      <ol>
+        <li>
+          <strong>Reverse proxy</strong> — route{" "}
+          <code>&lt;app&gt;.localhost</code> to your local ports, powered by
+          Cloudflare Pingora
+        </li>
+        <li>
+          <strong>Process manager</strong> — spawn, monitor, and auto-restart
+          your dev services with deterministic port assignment
+        </li>
+        <li>
+          <strong>Traffic inspector</strong> — capture every HTTP request and
+          response with full headers and bodies, persisted to SQLite
+        </li>
+        <li>
+          <strong>Request replay &amp; mocking</strong> — re-send captured
+          requests with overrides, or create mock responses without hitting
+          upstream
+        </li>
+        <li>
+          <strong>Network simulation</strong> — inject latency, packet loss, and
+          bandwidth throttling per-app to test degraded conditions
+        </li>
+      </ol>
+
+      <p>Here&apos;s what it looks like in practice:</p>
+
+      <CodeBlock
+        lang="shellscript"
+        code={`# Start your frontend — it gets http://web.localhost:1337
+$ portzero web pnpm dev
+
+# Start your API — it gets http://api.localhost:1337
+$ portzero api cargo run
+
+# See everything running
+$ portzero list
+  web   Running  http://web.localhost:1337  (pid 12345)
+  api   Running  http://api.localhost:1337  (pid 12346)
+
+# Tail logs from your API
+$ portzero logs api -f`}
+      />
+
+      <p>No config files. No port numbers to remember. Just names.</p>
+
+      <h2>Why Rust?</h2>
+      <p>
+        A dev proxy sits in the hot path of every HTTP request you make during
+        development. It needs to be fast enough that you forget it&apos;s there.
+        Rust gives us that — sub-millisecond proxy overhead — plus a single
+        static binary with no runtime dependencies.
+      </p>
+      <p>
+        We built on top of{" "}
+        <a
+          href="https://github.com/cloudflare/pingora"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Cloudflare Pingora
+        </a>
+        , the same proxy framework that handles a significant chunk of
+        internet traffic at Cloudflare. It gives us HTTP/1, HTTP/2, and WebSocket
+        support out of the box, with battle-tested connection pooling and TLS.
+      </p>
+
+      <h2>The Desktop App</h2>
+      <p>
+        One thing that sets PortZero apart is the native desktop app, built with{" "}
+        <a
+          href="https://tauri.app"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Tauri v2
+        </a>
+        . While the CLI gives you full control, the desktop app makes traffic
+        inspection and mocking visual and immediate:
+      </p>
+      <ul>
+        <li>See all running apps with CPU, memory, and uptime at a glance</li>
+        <li>Browse and filter every HTTP request flowing through the proxy</li>
+        <li>Create mock responses with a form instead of writing JSON</li>
+        <li>Configure network simulation per-app with sliders</li>
+        <li>Manage the daemon from the system tray</li>
+      </ul>
+      <p>
+        This is the biggest gap I saw in tools like Portless — when you&apos;re
+        debugging a tricky API interaction, you want to <em>see</em> the
+        requests, not grep through logs. A visual dashboard turns traffic
+        inspection from a chore into something you actually use.
+      </p>
+
+      <h2>Multi-App Config</h2>
+      <p>
+        For projects with multiple services, PortZero supports a{" "}
+        <code>portzero.toml</code> config file:
+      </p>
+
+      <CodeBlock
+        lang="toml"
+        filename="portzero.toml"
+        code={`[proxy]
+port = 1337
+https = true
+
+[apps.web]
+command = "pnpm dev"
+cwd = "./apps/web"
+
+[apps.api]
+command = "cargo run"
+subdomain = "api"
+
+[apps.worker]
+command = "node worker.js"
+subdomain = "worker"`}
+      />
+
+      <p>
+        Run <code>portzero up</code> and all three services start with stable
+        URLs. Run <code>portzero down</code> to stop them all. That&apos;s it.
+      </p>
+
+      <h2>What&apos;s Next</h2>
+      <p>PortZero is open source and actively developed. Coming soon:</p>
+      <ul>
+        <li>
+          <strong>Public tunnels</strong> — expose local apps to the internet
+          with a single command, built on QUIC
+        </li>
+        <li>
+          <strong>Windows support</strong> — currently macOS and Linux only
+        </li>
+        <li>
+          <strong>API schema inference</strong> — automatically detect and
+          document your API&apos;s shape from captured traffic
+        </li>
+        <li>
+          <strong>Team sharing</strong> — share mock configurations and traffic
+          snapshots with your team
+        </li>
+      </ul>
+
+      <h2>Try It</h2>
+      <CodeBlock
+        lang="shellscript"
+        code={`# Install
+curl -fsSL https://goport0.dev/install.sh | bash
+
+# Run your app
+portzero my-app next dev
+
+# Open http://my-app.localhost:1337`}
+      />
+
+      <p>
+        Check out the{" "}
+        <a href="https://github.com/portzero-dev/portzero">
+          GitHub repo
+        </a>
+        , read the{" "}
+        <a href="/docs/getting-started">docs</a>, or{" "}
+        <a href="/#download">download the desktop app</a>.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/blog/posts/introducing-portzero.tsx
+++ b/apps/web/src/app/blog/posts/introducing-portzero.tsx
@@ -69,8 +69,9 @@ export default async function IntroducingPortZero() {
 
       <h2>What PortZero Does Differently</h2>
       <p>
-        PortZero is a single Rust binary that combines five things that usually
-        require separate tools:
+        PortZero is a single Rust binary that combines{" "}
+        <a href="/docs/features">five things</a> that usually require separate
+        tools:
       </p>
       <ol>
         <li>
@@ -141,7 +142,8 @@ $ portzero logs api -f`}
 
       <h2>The Desktop App</h2>
       <p>
-        One thing that sets PortZero apart is the native desktop app, built with{" "}
+        One thing that sets PortZero apart is the{" "}
+        <a href="/docs/desktop-app">native desktop app</a>, built with{" "}
         <a
           href="https://tauri.app"
           target="_blank"
@@ -169,7 +171,10 @@ $ portzero logs api -f`}
       <h2>Multi-App Config</h2>
       <p>
         For projects with multiple services, PortZero supports a{" "}
-        <code>portzero.toml</code> config file:
+        <a href="/docs/configuration">
+          <code>portzero.toml</code> config file
+        </a>
+        :
       </p>
 
       <CodeBlock
@@ -231,7 +236,11 @@ portzero my-app next dev
 
       <p>
         Check out the{" "}
-        <a href="https://github.com/portzero-dev/portzero">
+        <a
+          href="https://github.com/portzero-dev/portzero"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           GitHub repo
         </a>
         , read the{" "}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -127,7 +127,7 @@ html {
   padding: 0;
   color: #d4d4d8;
   font-size: 0.875rem;
-  line-height: 1.7;
+  line-height: 1.5;
 }
 
 .docs-content table {
@@ -184,7 +184,7 @@ html {
   background: transparent !important;
   padding: 0 !important;
   font-size: 0.875rem;
-  line-height: 1.7;
+  line-height: 1.5;
 }
 
 .code-block .shiki {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -58,6 +58,12 @@ function Navbar() {
             Docs
           </a>
           <a
+            href="/blog"
+            className="text-sm text-zinc-400 transition-colors hover:text-white"
+          >
+            Blog
+          </a>
+          <a
             href="https://github.com/portzero-dev/portzero"
             target="_blank"
             rel="noopener noreferrer"
@@ -695,6 +701,12 @@ function Footer() {
               className="transition-colors hover:text-zinc-300"
             >
               Docs
+            </a>
+            <a
+              href="/blog"
+              className="transition-colors hover:text-zinc-300"
+            >
+              Blog
             </a>
             <a
               href="https://github.com/portzero-dev/portzero"

--- a/apps/web/src/components/blog-post-json-ld.tsx
+++ b/apps/web/src/components/blog-post-json-ld.tsx
@@ -1,0 +1,82 @@
+import type { BlogPost } from "@/lib/blog";
+
+export function BlogPostJsonLd({ post }: { post: BlogPost }) {
+  const url = `https://goport0.dev/blog/${post.slug}`;
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "BlogPosting",
+        "@id": `${url}#article`,
+        headline: post.title,
+        description: post.description,
+        datePublished: post.date,
+        dateModified: post.date,
+        author: {
+          "@type": "Person",
+          "@id": "https://goport0.dev/#author",
+          name: "David Viejo",
+          url: "https://x.com/davidviejodev",
+          sameAs: ["https://x.com/davidviejodev"],
+        },
+        publisher: {
+          "@type": "Organization",
+          "@id": "https://goport0.dev/#organization",
+          name: "PortZero",
+          url: "https://goport0.dev",
+          logo: {
+            "@type": "ImageObject",
+            url: "https://goport0.dev/icon.svg",
+          },
+        },
+        mainEntityOfPage: {
+          "@type": "WebPage",
+          "@id": url,
+        },
+        keywords: post.tags.join(", "),
+        wordCount: parseInt(post.readingTime) * 200,
+        inLanguage: "en-US",
+        isPartOf: {
+          "@type": "Blog",
+          "@id": "https://goport0.dev/blog#blog",
+          name: "PortZero Blog",
+          publisher: {
+            "@id": "https://goport0.dev/#organization",
+          },
+        },
+      },
+      {
+        "@type": "BreadcrumbList",
+        "@id": `${url}#breadcrumb`,
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "Home",
+            item: "https://goport0.dev",
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "Blog",
+            item: "https://goport0.dev/blog",
+          },
+          {
+            "@type": "ListItem",
+            position: 3,
+            name: post.title,
+            item: url,
+          },
+        ],
+      },
+    ],
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+    />
+  );
+}

--- a/apps/web/src/lib/blog.ts
+++ b/apps/web/src/lib/blog.ts
@@ -11,9 +11,9 @@ export interface BlogPost {
 export const posts: BlogPost[] = [
   {
     slug: "introducing-portzero",
-    title: "Introducing PortZero: Why I Built a New Local Dev Proxy",
+    title: "Why I Built PortZero, a New Local Dev Proxy",
     description:
-      "The story behind PortZero — a single Rust binary that gives your local dev servers stable URLs, traffic inspection, and more.",
+      "PortZero is a single Rust binary that replaces 5 separate dev tools. Get stable .localhost URLs, traffic inspection, mocking, replay, and sub-ms proxy overhead.",
     date: "2026-03-14",
     author: "David Viejo",
     tags: ["announcement", "rust", "developer-tools"],

--- a/apps/web/src/lib/blog.ts
+++ b/apps/web/src/lib/blog.ts
@@ -1,0 +1,32 @@
+export interface BlogPost {
+  slug: string;
+  title: string;
+  description: string;
+  date: string;
+  author: string;
+  tags: string[];
+  readingTime: string;
+}
+
+export const posts: BlogPost[] = [
+  {
+    slug: "introducing-portzero",
+    title: "Introducing PortZero: Why I Built a New Local Dev Proxy",
+    description:
+      "The story behind PortZero — a single Rust binary that gives your local dev servers stable URLs, traffic inspection, and more.",
+    date: "2026-03-14",
+    author: "David Viejo",
+    tags: ["announcement", "rust", "developer-tools"],
+    readingTime: "6 min read",
+  },
+];
+
+export function getAllPosts(): BlogPost[] {
+  return posts.sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+  );
+}
+
+export function getPost(slug: string): BlogPost | undefined {
+  return posts.find((p) => p.slug === slug);
+}


### PR DESCRIPTION
## Summary
- Add blog infrastructure: listing page, dynamic post pages, layout with navigation
- First post: "Why I Built PortZero, a New Local Dev Proxy" covering the problem, alternatives (Nginx/Caddy/Traefik, Ngrok, Portless), and what PortZero does differently
- Full SEO: JSON-LD schema (BlogPosting, Person, Organization, BreadcrumbList), Twitter Cards (@davidviejodev), OpenGraph meta, canonical URLs
- Fix dompurify XSS vulnerability by updating mermaid 11.12.3 → 11.13.0
- Code block styling fix (line-height 1.7 → 1.5)

## Test plan
- [ ] Verify blog listing at /blog shows the post
- [ ] Verify blog post renders at /blog/introducing-portzero
- [ ] Validate JSON-LD with Google Rich Results Test
- [ ] Check Twitter Card preview with card validator
- [ ] Confirm internal links (/docs/features, /docs/configuration, /docs/desktop-app) work